### PR TITLE
fix(second-brain): slowed button animation speed

### DIFF
--- a/src/components/ui/second-brain.tsx
+++ b/src/components/ui/second-brain.tsx
@@ -28,7 +28,7 @@ const SecondBrain = ({ text }: { text: string }) => {
 
         <span
           className={cn(
-            "absolute w-8 h-[200%] bg-indigo-100/10 -top-1/2 -left-5 -z-[20] rotate-12 transition-all duration-300",
+            "absolute w-8 h-[200%] bg-indigo-100/10 -top-1/2 -left-5 -z-[20] rotate-12 transition-all duration-700",
             hovering && "left-[90%]"
           )}
         />


### PR DESCRIPTION
## Description

This PR slows down the hover animation on the `SecondBrain` button component. The sliding shine effect was too fast, making it nearly unnoticeable. The transition duration has been increased from `300ms` to `700ms` for a smoother and more visible effect.

Fixes #62 

## Type of change

- [x] Bug fix
- [ ] New feature

## Screenshots / Video

https://github.com/user-attachments/assets/ab59e12e-48f7-4384-9c44-0a245efe4c48  

## How Has This Been Tested?

- Manually tested the button in the local development server (`bun run dev`)
- Verified that the animation is now visibly slower and more fluid on hover

## Checklist:

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings

> Suggested Label: `easy` or `good first issue`