### PR TITLE
fix(bun.lock): The missing dependency is added

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -30,6 +30,7 @@
         "next": "14.2.13",
         "react": "^18",
         "react-dom": "^18",
+        "react-icons": "^5.5.0",
         "react-quill": "^2.0.0",
         "tailwind-merge": "^2.5.2",
         "tailwindcss-animate": "^1.0.7",
@@ -1407,6 +1408,8 @@
     "react": ["react@18.3.1", "", { "dependencies": { "loose-envify": "^1.1.0" } }, "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ=="],
 
     "react-dom": ["react-dom@18.3.1", "", { "dependencies": { "loose-envify": "^1.1.0", "scheduler": "^0.23.2" }, "peerDependencies": { "react": "^18.3.1" } }, "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw=="],
+
+    "react-icons": ["react-icons@5.5.0", "", { "peerDependencies": { "react": "*" } }, "sha512-MEFcXdkP3dLo8uumGI5xN3lDFNsRtrjbOEKDLD7yv76v4wpnEq2Lt2qeHaQOr34I/wPN3s3+N08WkQ+CW37Xiw=="],
 
     "react-is": ["react-is@18.3.1", "", {}, "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="],
 


### PR DESCRIPTION
## Description

This PR addresses an inconsistency with how the bun.lockb file updates after installing packages using Bun.
Previously, when installing react-icons via bun add, the bun.lockb file did not update in some sessions. However, repeating the same command in a fresh session did modify the lockfile.
This fix aims to ensure that lockfile updates are reliable and consistent across all installs.

Fixes #92 

## Type of change

- [x] Bug fix
- [ ] New feature

## Screenshots / Video

![image](https://github.com/user-attachments/assets/6fb5fbf6-b2a3-4d15-979c-c9d0340a4952)

## How Has This Been Tested?

1. Installed react-icons in a fresh clone using bun add react-icons
2. Verified that bun.lockb updates properly
3. Removed and reinstalled the package to confirm consistency
4. Re-ran bun install multiple times to ensure idempotency

## Checklist:

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] The lockfile change is now tracked and consistent
